### PR TITLE
max_keep_alive and non blocking reading of request

### DIFF
--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -870,6 +870,9 @@ type t = {
 let addr self = self.addr
 let port self = self.port
 
+let available_connections self =
+  Sem_.available_connections self.sem_max_connections
+
 let add_decode_request_cb self f =  self.cb_decode_req <- f :: self.cb_decode_req
 let add_encode_response_cb self f = self.cb_encode_resp <- f :: self.cb_encode_resp
 let set_top_handler self f = self.handler <- f

--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -724,7 +724,8 @@ module Sem_ = struct
     Condition.broadcast t.cond;
     Mutex.unlock t.mutex
 
-  let available_connections t = t.n
+  (* +1 because we decrease the semaphore before Unix.accept *)
+  let available_connections t = t.n + 1
 
 end
 
@@ -1123,8 +1124,8 @@ let run (self:t) : (unit,_) result =
     while self.running do
       (* limit concurrency *)
       try
-        let client_sock, _ = Unix.accept sock in
         Sem_.acquire 1 self.sem_max_connections;
+        let client_sock, _ = Unix.accept sock in
         self.new_thread
           (fun () ->
             try

--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -1000,8 +1000,9 @@ let find_map f l =
   in aux f l
 
 let handle_client_ (self:t) (client_sock:Unix.file_descr) : unit =
+  let write_sock = Unix.dup client_sock in
   let _ = Unix.set_nonblock client_sock in
-  let oc = Unix.out_channel_of_descr client_sock in
+  let oc = Unix.out_channel_of_descr write_sock in
   let buf = Buf_.create() in
   let is = Byte_stream.of_descr ~timeout:self.max_keep_alive client_sock in
   let continue = ref true in

--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -724,12 +724,8 @@ module Sem_ = struct
     Condition.broadcast t.cond;
     Mutex.unlock t.mutex
 
-  let available_connection t =
-    (* locking necessary unless we have atomic read/write for int.*)
-    Mutex.lock t.mutex;
-    let r = t.n in
-    Mutex.unlock t.mutex;
-    r
+  let available_connections t = t.n
+
 end
 
 module Route = struct
@@ -1133,14 +1129,14 @@ let run (self:t) : (unit,_) result =
               Sem_.release 1 self.sem_max_connections;
               _debug (fun k -> k
                 "closing inactive connections (%d connections available)"
-                (Sem_.available_connection self.sem_max_connections))
+                (Sem_.available_connections self.sem_max_connections))
             with
             | e ->
               (try Unix.close client_sock with _ -> ());
               Sem_.release 1 self.sem_max_connections;
               _debug (fun k -> k
                 "closing connections on error (%d connections available)"
-                (Sem_.available_connection self.sem_max_connections));
+                (Sem_.available_connections self.sem_max_connections));
               raise e
           );
       with e ->

--- a/src/Tiny_httpd.mli
+++ b/src/Tiny_httpd.mli
@@ -434,6 +434,7 @@ type t
 val create :
   ?masksigpipe:bool ->
   ?max_connections:int ->
+  ?max_keep_alive:float ->
   ?new_thread:((unit -> unit) -> unit) ->
   ?addr:string ->
   ?port:int ->
@@ -453,7 +454,10 @@ val create :
     new client connection. By default it is {!Thread.create} but one
     could use a thread pool instead.
 
-    @param max_connections maximum number of simultaneous connections.
+    @param max_connections maximum number of simultaneous connections. Default 32.
+    @param max_keep_alive maximum number of seconds a thread in maintened for
+      a client with nothing to read. Default: -1.0, meaning threads are maintened
+      until client close the socket.
     @param addr address (IPv4 or IPv6) to listen on. Default ["127.0.0.1"].
     @param port to listen on. Default [8080].
     @param sock an existing socket given to the server to listen on, e.g. by
@@ -639,4 +643,3 @@ val _debug : ((('a, out_channel, unit, unit, unit, unit) format6 -> 'a) -> unit)
 val _enable_debug: bool -> unit
 
 (**/**)
-

--- a/src/Tiny_httpd.mli
+++ b/src/Tiny_httpd.mli
@@ -477,6 +477,9 @@ val is_ipv6 : t -> bool
 val port : t -> int
 (** Port on which the server listens. *)
 
+val available_connections : t -> int
+(** number of available connections on the server. *)
+
 val add_decode_request_cb :
   t ->
   (unit Request.t -> (unit Request.t * (byte_stream -> byte_stream)) option) -> unit


### PR DESCRIPTION
I experienced bad behavior of my server due to client not closing sockets (and a proxy makes it worth). Just increasing
max_connection is not enough, closing the navigator still does no close the socket. I needed two fixes to handle that:

- I added a max_keep_alive to automatically close socket if there is no new request for some time (defaut is -1.0)
  not to break existing code.

- the reading of request is now using Unix.read and a non blocking socket to make sure we are not blocking on Stdlib.input 
  which was a behavior I observed very frequently.