### PR TITLE
Wip middleware

### DIFF
--- a/examples/echo.ml
+++ b/examples/echo.ml
@@ -13,7 +13,7 @@ let middleware_stat () : S.Middleware.t * (unit -> string) =
 
   let m h req ~resp =
     incr n_req;
-    let t1 = S.Request.time req in
+    let t1 = S.Request.time_start req in
     let t2 = now_ () in
     h req ~resp:(fun response ->
         let t3 = now_ () in

--- a/examples/echo.ml
+++ b/examples/echo.ml
@@ -13,7 +13,7 @@ let middleware_stat () : S.Middleware.t * (unit -> string) =
 
   let m h req ~resp =
     incr n_req;
-    let t1 = S.Request.time_start req in
+    let t1 = S.Request.start_time req in
     let t2 = now_ () in
     h req ~resp:(fun response ->
         let t3 = now_ () in

--- a/examples/echo.ml
+++ b/examples/echo.ml
@@ -10,15 +10,15 @@ let middleware_stat () : S.Middleware.t * (unit -> string) =
 
   let m h req ~resp =
     incr n_req;
-    let t1 = now_ () in
+    let t1 = S.Request.time req in
     h req ~resp:(fun response ->
         resp response;
         let t2 = now_ () in
         total_time_ := !total_time_ +. (t2 -. t1);
       )
   and get_stat () =
-    Printf.sprintf "%d requests (average response time: %.3fs)"
-      !n_req (!total_time_ /. float !n_req)
+    Printf.sprintf "%d requests (average response time: %.3fms)"
+      !n_req (!total_time_ /. float !n_req *. 1e3)
   in
   m, get_stat
 

--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -367,7 +367,7 @@ module Request = struct
     path_components: string list;
     query: (string*string) list;
     body: 'body;
-    time: float;
+    start_time: float;
   }
 
   let headers self = self.headers
@@ -375,7 +375,7 @@ module Request = struct
   let meth self = self.meth
   let path self = self.path
   let body self = self.body
-  let time self = self.time
+  let start_time self = self.start_time
 
   let non_query_path self = Tiny_httpd_util.get_non_query_path self.path
 
@@ -487,7 +487,7 @@ module Request = struct
   let parse_req_start ~buf (bs:byte_stream) : unit t option resp_result =
     try
       let line = Byte_stream.read_line ~buf bs in
-      let time = Unix.gettimeofday () in
+      let start_time = Unix.gettimeofday () in
       let meth, path =
         try
           let m, p, v = Scanf.sscanf line "%s %s HTTP/1.%d\r" (fun x y z->x,y,z) in
@@ -513,7 +513,7 @@ module Request = struct
         | Error e -> bad_reqf 400 "invalid query: %s" e
       in
       Ok (Some {meth; query; host; path; path_components;
-                headers; body=(); time})
+                headers; body=(); start_time; })
     with
     | End_of_file | Sys_error _ -> Ok None
     | Bad_req (c,s) -> Error (c,s)

--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -367,6 +367,7 @@ module Request = struct
     path_components: string list;
     query: (string*string) list;
     body: 'body;
+    time: float;
   }
 
   let headers self = self.headers
@@ -374,6 +375,7 @@ module Request = struct
   let meth self = self.meth
   let path self = self.path
   let body self = self.body
+  let time self = self.time
 
   let non_query_path self = Tiny_httpd_util.get_non_query_path self.path
 
@@ -485,6 +487,7 @@ module Request = struct
   let parse_req_start ~buf (bs:byte_stream) : unit t option resp_result =
     try
       let line = Byte_stream.read_line ~buf bs in
+      let time = Unix.gettimeofday () in
       let meth, path =
         try
           let m, p, v = Scanf.sscanf line "%s %s HTTP/1.%d\r" (fun x y z->x,y,z) in
@@ -510,7 +513,7 @@ module Request = struct
         | Error e -> bad_reqf 400 "invalid query: %s" e
       in
       Ok (Some {meth; query; host; path; path_components;
-                headers; body=()})
+                headers; body=(); time})
     with
     | End_of_file | Sys_error _ -> Ok None
     | Bad_req (c,s) -> Error (c,s)

--- a/src/Tiny_httpd.mli
+++ b/src/Tiny_httpd.mli
@@ -227,7 +227,7 @@ module Request : sig
     path_components: string list;
     query: (string*string) list;
     body: 'body;
-    time: float;
+    start_time: float; (** @since NEXT_RELEASE *)
   }
   (** A request with method, path, host, headers, and a body, sent by a client.
 

--- a/src/Tiny_httpd.mli
+++ b/src/Tiny_httpd.mli
@@ -281,8 +281,9 @@ module Request : sig
   val body : 'b t -> 'b
   (** Request body, possibly empty. *)
 
-  val time : 'b t -> float
-  (** time (from [Unix.gettimeofday] after parsing the first line*)
+  val start_time : _ t -> float
+  (** time stamp (from {!Unix.gettimeofday}) after parsing the first line of the request
+      @since NEXT_RELEASE *)
 
   val limit_body_size : max_size:int -> byte_stream t -> byte_stream t
   (** Limit the body size to [max_size] bytes, or return

--- a/src/Tiny_httpd.mli
+++ b/src/Tiny_httpd.mli
@@ -227,6 +227,7 @@ module Request : sig
     path_components: string list;
     query: (string*string) list;
     body: 'body;
+    time: float;
   }
   (** A request with method, path, host, headers, and a body, sent by a client.
 
@@ -279,6 +280,9 @@ module Request : sig
 
   val body : 'b t -> 'b
   (** Request body, possibly empty. *)
+
+  val time : 'b t -> float
+  (** time (from [Unix.gettimeofday] after parsing the first line*)
 
   val limit_body_size : max_size:int -> byte_stream t -> byte_stream t
   (** Limit the body size to [max_size] bytes, or return


### PR DESCRIPTION
Add Time after parsing first line of request (hopefully after receiving first TCP packet).
Using SO_TIMESTAMPING_* options would be better but it is not in Unix.mli yet, and not available on many systems too.