### PR TITLE
Use fd

### DIFF
--- a/src/Tiny_httpd_dir.ml
+++ b/src/Tiny_httpd_dir.ml
@@ -82,8 +82,8 @@ let vfs_of_dir (top:string) : vfs =
     let contains f = Sys.file_exists (top // f)
     let list_dir f = Sys.readdir (top // f)
     let read_file_content f =
-      let ic = open_in_bin (top // f) in
-      Tiny_httpd_stream.of_chan ic
+      let ic = Unix.(openfile (top // f) [O_RDONLY] 0) in
+      Tiny_httpd_stream.of_fd ic
     let create f =
       let oc = open_out_bin (top // f) in
       let write = output oc in
@@ -398,4 +398,3 @@ module Embedded_fs = struct
     end in (module M)
 
 end
-

--- a/src/Tiny_httpd_server.ml
+++ b/src/Tiny_httpd_server.ml
@@ -756,10 +756,9 @@ let find_map f l =
 let handle_client_ (self:t) (client_sock:Unix.file_descr) : unit =
   Unix.(setsockopt_float client_sock SO_RCVTIMEO self.timeout);
   Unix.(setsockopt_float client_sock SO_SNDTIMEO self.timeout);
-  let ic = Unix.in_channel_of_descr client_sock in
   let oc = Unix.out_channel_of_descr client_sock in
   let buf = Buf.create ~size:self.buf_size () in
-  let is = Byte_stream.of_chan ~buf_size:self.buf_size ic in
+  let is = Byte_stream.of_fd ~buf_size:self.buf_size client_sock in
   let continue = ref true in
   while !continue && self.running do
     _debug (fun k->k "read next request");

--- a/src/Tiny_httpd_stream.ml
+++ b/src/Tiny_httpd_stream.ml
@@ -120,13 +120,13 @@ let of_string s : t =
   of_bytes (Bytes.unsafe_of_string s)
 
 let with_file ?buf_size file f =
-  let ic = open_in file in
+  let ic = Unix.(openfile file [O_RDONLY] 0) in
   try
-    let x = f (of_chan ?buf_size ic) in
-    close_in ic;
+    let x = f (of_fd ?buf_size ic) in
+    Unix.close ic;
     x
   with e ->
-    close_in_noerr ic;
+    Unix.close ic;
     raise e
 
 let read_all ?(buf=Buf.create()) (self:t) : string =

--- a/src/Tiny_httpd_stream.mli
+++ b/src/Tiny_httpd_stream.mli
@@ -50,6 +50,12 @@ val of_chan : ?buf_size:int -> in_channel -> t
 val of_chan_close_noerr : ?buf_size:int -> in_channel -> t
 (** Same as {!of_chan} but the [close] method will never fail. *)
 
+val of_fd : ?buf_size:int -> Unix.file_descr -> t
+(** Make a buffered stream from the given file descriptor. *)
+
+val of_fd_close_noerr : ?buf_size:int -> Unix.file_descr -> t
+(** Same as {!of_fd} but the [close] method will never fail. *)
+
 val of_bytes : ?i:int -> ?len:int -> bytes -> t
 (** A stream that just returns the slice of bytes starting from [i]
     and of length [len]. *)


### PR DESCRIPTION
Before trying to use domains for real, I felt it is better to replace in channel by file descriptor to avoid stacking
two buffers. It should be and seems like a few percent faster but would need real testing to check.

I kept of_chan, but it is not used anymore .... May be we should remove it?