### PR TITLE
Pass status code to response makers

### DIFF
--- a/src/Tiny_httpd_server.ml
+++ b/src/Tiny_httpd_server.ml
@@ -405,27 +405,27 @@ module Response = struct
     else
       make_raw ~headers ~code "" (* invalid to not have a body *)
 
-  let make_string ?headers r =
+  let make_string ?headers ?(code=200) r =
     match r with
-    | Ok body -> make_raw ?headers ~code:200 body
+    | Ok body -> make_raw ?headers ~code body
     | Error (code, msg) -> make_raw ?headers ~code msg
 
-  let make_stream ?headers r =
+  let make_stream ?headers ?(code=200) r =
     match r with
-    | Ok body -> make_raw_stream ?headers ~code:200 body
+    | Ok body -> make_raw_stream ?headers ~code body
     | Error (code, msg) -> make_raw ?headers ~code msg
 
-  let make_writer ?headers r : t =
+  let make_writer ?headers ?(code=200) r : t =
     match r with
-    | Ok body -> make_raw_writer ?headers ~code:200 body
+    | Ok body -> make_raw_writer ?headers ~code body
     | Error (code, msg) -> make_raw ?headers ~code msg
 
-  let make ?headers r : t =
+  let make ?headers ?(code=200) r : t =
     match r with
-    | Ok (`String body) -> make_raw ?headers ~code:200 body
-    | Ok (`Stream body) -> make_raw_stream ?headers ~code:200 body
-    | Ok `Void -> make_void ?headers ~code:200 ()
-    | Ok (`Writer f) -> make_raw_writer ?headers ~code:200 f
+    | Ok (`String body) -> make_raw ?headers ~code body
+    | Ok (`Stream body) -> make_raw_stream ?headers ~code body
+    | Ok `Void -> make_void ?headers ~code ()
+    | Ok (`Writer f) -> make_raw_writer ?headers ~code f
     | Error (code, msg) -> make_raw ?headers ~code msg
 
   let fail ?headers ~code fmt =

--- a/src/Tiny_httpd_server.mli
+++ b/src/Tiny_httpd_server.mli
@@ -251,7 +251,11 @@ module Response : sig
   (** Return a response without a body at all.
       @since 0.13 *)
 
-  val make : ?headers:Headers.t -> (body, Response_code.t * string) result -> t
+  val make :
+    ?headers:Headers.t ->
+    ?code:int ->
+    (body, Response_code.t * string) result ->
+    t
   (** [make r] turns a result into a response.
 
       - [make (Ok body)] replies with [200] and the body.
@@ -260,17 +264,24 @@ module Response : sig
   *)
 
   val make_string :
-    ?headers:Headers.t -> (string, Response_code.t * string) result -> t
+    ?headers:Headers.t ->
+    ?code:int ->
+    (string, Response_code.t * string) result ->
+    t
   (** Same as {!make} but with a string body. *)
 
   val make_writer :
     ?headers:Headers.t ->
+    ?code:int ->
     (Tiny_httpd_io.Writer.t, Response_code.t * string) result ->
     t
   (** Same as {!make} but with a writer body. *)
 
   val make_stream :
-    ?headers:Headers.t -> (byte_stream, Response_code.t * string) result -> t
+    ?headers:Headers.t ->
+    ?code:int ->
+    (byte_stream, Response_code.t * string) result ->
+    t
   (** Same as {!make} but with a stream body. *)
 
   val fail :


### PR DESCRIPTION
In our application, we will use `Ok()` exclusively since we need to use the writer scheme and not a monolithic string in all cases. Therefore, we need to be able to pass the HTTP status code to the make function.

Note that this leaves the `Error()` case intact.

Also, `ocamlformat` crashes complaining that I need `0.24.1` while I run `0.26.0`. I thought it would support multiple versions with that config setting but apparently it's just an assertion to avoid conflicts.  So, I can't format and I did it manually as a best guess of what it should look like.