### PR TITLE
add optional dependency on `logs`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
   (synopsis "Minimal HTTP server using threads")
   (tags (http thread server tiny_httpd http_of_dir simplehttpserver))
   (depopts
+    logs
     (mtime (>= 2.0)))
   (depends
     seq

--- a/examples/dune
+++ b/examples/dune
@@ -1,7 +1,7 @@
 (executable
  (name sse_server)
  (modules sse_server)
- (libraries tiny_httpd unix ptime ptime.clock.os))
+ (libraries tiny_httpd logs unix ptime ptime.clock.os))
 
 (executable
  (name sse_client)
@@ -12,13 +12,13 @@
  (name echo)
  (flags :standard -warn-error -a+8)
  (modules echo vfs)
- (libraries tiny_httpd tiny_httpd_camlzip))
+ (libraries tiny_httpd logs tiny_httpd_camlzip))
 
 (executable
  (name writer)
  (flags :standard -warn-error -a+8)
  (modules writer)
- (libraries tiny_httpd))
+ (libraries tiny_httpd logs))
 
 (rule
  (targets test_output.txt)

--- a/src/Tiny_httpd.ml
+++ b/src/Tiny_httpd.ml
@@ -6,3 +6,4 @@ module Dir = Tiny_httpd_dir
 module Html = Tiny_httpd_html
 module IO = Tiny_httpd_io
 module Pool = Tiny_httpd_pool
+module Log = Tiny_httpd_log

--- a/src/Tiny_httpd.mli
+++ b/src/Tiny_httpd.mli
@@ -89,6 +89,10 @@ module Byte_stream = Tiny_httpd_stream
 
 module IO = Tiny_httpd_io
 
+(** {2 Logging *)
+
+module Log = Tiny_httpd_log
+
 (** {2 Main Server Type} *)
 
 (** @inline *)

--- a/src/Tiny_httpd_log.default.ml
+++ b/src/Tiny_httpd_log.default.ml
@@ -1,0 +1,6 @@
+(* default: no logging *)
+
+let info _ = ()
+let debug _ = ()
+let error _ = ()
+let enable ~debug:_ () = ()

--- a/src/Tiny_httpd_log.default.ml
+++ b/src/Tiny_httpd_log.default.ml
@@ -4,3 +4,4 @@ let info _ = ()
 let debug _ = ()
 let error _ = ()
 let enable ~debug:_ () = ()
+let dummy = true

--- a/src/Tiny_httpd_log.logs.ml
+++ b/src/Tiny_httpd_log.logs.ml
@@ -14,3 +14,5 @@ let setup ~debug () =
          Logs.Debug
        else
          Logs.Info))
+
+let dummy = false

--- a/src/Tiny_httpd_log.logs.ml
+++ b/src/Tiny_httpd_log.logs.ml
@@ -1,0 +1,16 @@
+(* Use Logs *)
+
+module Log = (val Logs.(src_log @@ Src.create "tiny_httpd"))
+
+let info k = Log.info (fun fmt -> k (fun x -> fmt ?header:None ?tags:None x))
+let debug k = Log.debug (fun fmt -> k (fun x -> fmt ?header:None ?tags:None x))
+let error k = Log.err (fun fmt -> k (fun x -> fmt ?header:None ?tags:None x))
+
+let setup ~debug () =
+  Logs.set_reporter @@ Logs.format_reporter ();
+  Logs.set_level ~all:true
+    (Some
+       (if debug then
+         Logs.Debug
+       else
+         Logs.Info))

--- a/src/Tiny_httpd_log.mli
+++ b/src/Tiny_httpd_log.mli
@@ -8,3 +8,5 @@ val setup : debug:bool -> unit -> unit
 (** Setup and enable logging. This should only ever be used in executables,
     not libraries.
     @param debug if true, set logging to debug (otherwise info) *)
+
+val dummy : bool

--- a/src/Tiny_httpd_log.mli
+++ b/src/Tiny_httpd_log.mli
@@ -1,0 +1,10 @@
+(** Logging for tiny_httpd *)
+
+val info : ((('a, Format.formatter, unit, unit) format4 -> 'a) -> unit) -> unit
+val debug : ((('a, Format.formatter, unit, unit) format4 -> 'a) -> unit) -> unit
+val error : ((('a, Format.formatter, unit, unit) format4 -> 'a) -> unit) -> unit
+
+val setup : debug:bool -> unit -> unit
+(** Setup and enable logging. This should only ever be used in executables,
+    not libraries.
+    @param debug if true, set logging to debug (otherwise info) *)

--- a/src/Tiny_httpd_server.mli
+++ b/src/Tiny_httpd_server.mli
@@ -67,8 +67,7 @@ module Request : sig
     meth: Meth.t;  (** HTTP method for this request. *)
     host: string;
         (** Host header, mandatory. It can also be found in {!headers}. *)
-    client_addr: Unix.sockaddr;
-        (** Client address. Available since 0.14. *)
+    client_addr: Unix.sockaddr;  (** Client address. Available since 0.14. *)
     headers: Headers.t;  (** List of headers. *)
     http_version: int * int;
         (** HTTP version. This should be either [1, 0] or [1, 1]. *)
@@ -667,12 +666,3 @@ val run_exn : ?after_init:(unit -> unit) -> t -> unit
 (** [run_exn s] is like [run s] but re-raises an exception if the server exits
     with an error.
     @since 0.14 *)
-
-(**/**)
-
-val _debug :
-  ((('a, out_channel, unit, unit, unit, unit) format6 -> 'a) -> unit) -> unit
-
-val _enable_debug : bool -> unit
-
-(**/**)

--- a/src/bin/http_of_dir.ml
+++ b/src/bin/http_of_dir.ml
@@ -2,6 +2,7 @@ module S = Tiny_httpd
 module U = Tiny_httpd_util
 module D = Tiny_httpd_dir
 module Pf = Printf
+module Log = Tiny_httpd.Log
 
 let serve ~config (dir : string) addr port j : _ result =
   let server = S.create ~max_connections:j ~addr ~port () in
@@ -39,7 +40,7 @@ let main () =
          "--port", Set_int port, " port to listen on";
          "-p", Set_int port, " alias to --port";
          "--dir", Set_string dir_, " directory to serve (default: \".\")";
-         "--debug", Unit (fun () -> S._enable_debug true), " debug mode";
+         "--debug", Unit (Log.setup ~debug:true), " debug mode";
          ( "--upload",
            Unit (fun () -> config.upload <- true),
            " enable file uploading" );

--- a/src/dune
+++ b/src/dune
@@ -1,13 +1,10 @@
-
-(env
- (_
-  (flags :standard -warn-error -a+8 -w +a-4-32-40-42-44-48-70 -color always -safe-string
-    -strict-sequence)))
-
 (library
   (name tiny_httpd)
   (public_name tiny_httpd)
-  (libraries threads seq unix)
+  (libraries threads seq unix
+             (select Tiny_httpd_log.ml from
+              (logs -> Tiny_httpd_log.logs.ml)
+              (-> Tiny_httpd_log.default.ml)))
   (wrapped false))
 
 (rule

--- a/tiny_httpd.opam
+++ b/tiny_httpd.opam
@@ -22,6 +22,7 @@ depends: [
   "qcheck-core" {>= "0.9" & with-test}
 ]
 depopts: [
+  "logs"
   "mtime" {>= "2.0"}
 ]
 build: [


### PR DESCRIPTION
Logs is a de facto standard and it's too convenient to bypass
