### PR TITLE
Processing to fix incompatible -O and gcc flags

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.9)
+(lang dune 3.2)
 (name tiny_httpd)
 (generate_opam_files true)
 

--- a/src/ws/dune
+++ b/src/ws/dune
@@ -1,3 +1,28 @@
+; Set BUILD_TINY_HTTPD_OPTLEVEL to the -O<num> level.
+; Defaults to 2, which means -O2 is the default C optimization flag.
+; Use -1 to remove the -O<num> flag entirely.
+(rule
+ (enabled_if (>= %{env:BUILD_TINY_HTTPD_OPTLEVEL=2} 0))
+ (target optlevel.string)
+ (deps (env_var BUILD_TINY_HTTPD_OPTLEVEL))
+ (action (with-stdout-to %{target} (echo "-O%{env:BUILD_TINY_HTTPD_OPTLEVEL=2}"))))
+(rule
+ (enabled_if (< %{env:BUILD_TINY_HTTPD_OPTLEVEL=2} 0))
+ (target optlevel.string)
+ (deps (env_var BUILD_TINY_HTTPD_OPTLEVEL))
+ (action (with-stdout-to %{target} (echo ""))))
+
+; All compilers will include the optimization level.
+; Non-MSVC compilers will include `-std=c99 -fPIC`.
+(rule
+ (enabled_if (= %{ocaml-config:ccomp_type} msvc))
+ (target cflags.sexp)
+ (action (with-stdout-to %{target} (echo "(%{read:optlevel.string})"))))
+(rule
+ (enabled_if (not (= %{ocaml-config:ccomp_type} msvc)))
+ (target cflags.sexp)
+ (action (with-stdout-to %{target} (echo "(-std=c99 -fPIC %{read:optlevel.string})"))))
+
 (library
  (name tiny_httpd_ws)
  (public_name tiny_httpd.ws)
@@ -7,7 +32,7 @@
  (foreign_stubs
   (language c)
   (names tiny_httpd_ws_stubs)
-  (flags :standard -std=c99 -fPIC -O2))
+  (flags :standard (:include cflags.sexp)))
  (libraries
   (re_export tiny_httpd.core)
   threads))

--- a/tiny_httpd.opam
+++ b/tiny_httpd.opam
@@ -11,7 +11,7 @@ tags: [
 homepage: "https://github.com/c-cube/tiny_httpd/"
 bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.2"}
   "seq"
   "base-threads"
   "result"
@@ -38,11 +38,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"

--- a/tiny_httpd_camlzip.opam
+++ b/tiny_httpd_camlzip.opam
@@ -8,7 +8,7 @@ license: "MIT"
 homepage: "https://github.com/c-cube/tiny_httpd/"
 bug-reports: "https://github.com/c-cube/tiny_httpd/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.2"}
   "tiny_httpd" {= version}
   "camlzip" {>= "1.06"}
   "iostream-camlzip" {>= "0.2.1"}
@@ -24,11 +24,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/c-cube/tiny_httpd.git"


### PR DESCRIPTION
Main changes:

1. Accept BUILD_TINY_HTTPD_OPTLEVEL envvar to adjust the -O<num> level. Defaults to 2. Can be negative to remove it entirely, which fixes errors with MSVC which will bail on incompatible options.
2. Do not use -fPIC with MSVC

---

### Motivation

This is just a warning for most people:

```text
tiny_httpd_ws_stubs.c
cl : Command line warning D9002 : ignoring unknown option '-std=c99'
cl : Command line warning D9002 : ignoring unknown option '-fPIC'
```

But if you compile with debug flags like I do, you can get:

```text
File "DkFilesD/_opam/.opam-switch/build/tiny_httpd.0.17.0/src/ws/dune", line 10, characters 11-30:
10 |     (names tiny_httpd_ws_stubs)
                ^^^^^^^^^^^^^^^^^^^
          cl DkFilesD/_opam/.opam-switch/build/tiny_httpd.0.17.0/src/ws/tiny_httpd_ws_stubs.obj (exit 2)
(cd _build/default/DkFilesD/_opam/.opam-switch/build/tiny_httpd.0.17.0/src/ws && Y:/VS/VC/Tools/MSVC/14.38.33130/bin/Hostx64/x64/cl.exe -nologo -Gy- -MDd -DWIN32 -D_WINDOWS -Ob0 -Od -RTC1 -D_CRT_SECURE_NO_DEPRECATE -nologo -Gy- -MDd -DWIN32 -D_WINDOWS -Ob0 -Od -RTC1 -D_CRT_SECURE_NO_DEPRECATE -std=c99 -fPIC -O2 -I Y:/source/dksdk-foundations/build/d/st-d/o/lib/ocaml -I Y:/source/dksdk-foundations/build/d/st-d/o/lib/ocaml\threads -I ../../../hmap.0.8.1+dune/src -I ../../../iostream.0.3/src/core -I ../../../iostream.0.3/src/types -I ../../../seq.base/src -I ../core /Fotiny_httpd_ws_stubs.obj -c tiny_httpd_ws_stubs.c)
cl : Command line warning D9025 : overriding '/Od' with '/O2'
cl : Command line error D8016 : '/RTC1' and '/O2' command-line options are incompatible
```

### All Changes

1. No longer using unknown MSVC options like `-fPIC` with MSVC.
2. BUILD_TINY_HTTPD_OPTLEVEL can influence and remove `-O2`.
3. Had to bump up dune to 3.2 or else:

   ```text
   Error: 'not' is only available since version 3.2 of the dune language. Please
   update your dune-project file to have (lang dune 3.2).
   ```

### Testing

I used a different switch than what is in "Motivation" so it is easy to repeat.

With this PR (scroll to the right):

```console
$ opam exec -- ocamlc -config-var native_c_compiler
cl -nologo -O2 -Gy- -MD    -D_CRT_SECURE_NO_DEPRECATE 

$ opam exec -- dune build -p tiny_httpd --display short
          cl src/ws/tiny_httpd_ws_stubs.obj
(cd _build/default/src/ws && Y:\VS\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64\cl.exe -nologo -O2 -Gy- -MD -D_CRT_SECURE_NO_DEPRECATE -O2 -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml\threads -I Y:\source\MlFront_Archive\_opam\lib\hmap -I Y:\source\MlFront_Archive\_opam\lib\iostream -I Y:\source\MlFront_Archive\_opam\lib\logs -I Y:\source\MlFront_Archive\_opam\lib\seq -I ../core /Fotiny_httpd_ws_stubs.obj -c tiny_httpd_ws_stubs.c)

$ opam exec -- env BUILD_TINY_HTTPD_OPTLEVEL=1 dune build -p tiny_httpd --display short
          cl src/ws/tiny_httpd_ws_stubs.obj
(cd _build/default/src/ws && Y:\VS\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64\cl.exe -nologo -O2 -Gy- -MD -D_CRT_SECURE_NO_DEPRECATE -O1 -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml\threads -I Y:\source\MlFront_Archive\_opam\lib\hmap -I Y:\source\MlFront_Archive\_opam\lib\iostream -I Y:\source\MlFront_Archive\_opam\lib\logs -I Y:\source\MlFront_Archive\_opam\lib\seq -I ../core /Fotiny_httpd_ws_stubs.obj -c tiny_httpd_ws_stubs.c)
cl : Command line warning D9025 : overriding '/O2' with '/O1'

$ opam exec -- env BUILD_TINY_HTTPD_OPTLEVEL=0 dune build -p tiny_httpd --display short
          cl src/ws/tiny_httpd_ws_stubs.obj
(cd _build/default/src/ws && Y:\VS\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64\cl.exe -nologo -O2 -Gy- -MD -D_CRT_SECURE_NO_DEPRECATE -O0 -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml\threads -I Y:\source\MlFront_Archive\_opam\lib\hmap -I Y:\source\MlFront_Archive\_opam\lib\iostream -I Y:\source\MlFront_Archive\_opam\lib\logs -I Y:\source\MlFront_Archive\_opam\lib\seq -I ../core /Fotiny_httpd_ws_stubs.obj -c tiny_httpd_ws_stubs.c)
cl : Command line warning D9002 : ignoring unknown option '-O0'

$ opam exec -- env BUILD_TINY_HTTPD_OPTLEVEL=-1 dune build -p tiny_httpd --display short
          cl src/ws/tiny_httpd_ws_stubs.obj
(cd _build/default/src/ws && Y:\VS\VC\Tools\MSVC\14.40.33807\bin\HostX64\x64\cl.exe -nologo -O2 -Gy- -MD -D_CRT_SECURE_NO_DEPRECATE -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml -I C:/Users/beckf/AppData/Local/Programs/DKMLNA~1/lib/ocaml\threads -I Y:\source\MlFront_Archive\_opam\lib\hmap -I Y:\source\MlFront_Archive\_opam\lib\iostream -I Y:\source\MlFront_Archive\_opam\lib\logs -I Y:\source\MlFront_Archive\_opam\lib\seq -I ../core /Fotiny_httpd_ws_stubs.obj -c tiny_httpd_ws_stubs.c)
```
